### PR TITLE
fix typo in backend/core/settings.py

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -48,7 +48,7 @@ class Settings(BaseSettings):
     def validate_anthropic_key(cls, v):
         """ANTHROPIC_API_KEYが必須であることを検証"""
         if not v or not v.startswith("sk-"):
-            raise ValueError("Valid ANTHROPIC_API_KEY is requierd")
+            raise ValueError("Valid ANTHROPIC_API_KEY is required")
         return v
 
 


### PR DESCRIPTION
## Summary

Fix typo `reqierd` to `required` in `/backend/core/settings.py` line 51 ValueException message.

## Related Issue

Class #23 

## Changes

### Modified Files

- `backend/core/settings.py`

## Testing

- [x] Ruff lint passes
